### PR TITLE
Fix wrong behavior help

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -231,8 +231,8 @@ program
     }
   })
 
-if (!program._args.length) {
+program.parse(process.argv)
+
+if (program.rawArgs.length <= 2) {
   program.help()
 }
-
-program.parse(process.argv)


### PR DESCRIPTION
Implement a fix to following behavior: When the user not pass any argument or action, display the help message.