### PR TITLE
feat: suggest the closest match to an unknown command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "fs-extra": "^9.0.1",
     "github-download": "^0.5.0",
     "inquirer": "^7.3.2",
+    "leven": "^3.1.0",
     "lodash": "^4.17.15",
     "netrc": "0.1.4",
     "on-change": "^2.0.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ const chalk = require('chalk')
 const clear = require('clear')
 const figlet = require('figlet')
 const inquirer = require('inquirer')
+const leven = require('leven')
 
 const updateNotifier = require('update-notifier')
 const pkg = require('../package.json')
@@ -376,6 +377,18 @@ program
     } catch (e) {
       console.log(chalk.red('X') + ' An error ocurred to import data : ' + e.message)
       process.exit(1)
+    }
+  })
+
+program
+  .arguments('<command>')
+  .action((invalidCmd) => {
+    program.outputHelp()
+    console.log('  ' + chalk.red(`Unknown command ${chalk.yellow(invalidCmd)}.`))
+    const availableCommands = program.commands.map(cmd => cmd._name)
+    const suggestion = availableCommands.find(cmd => leven(cmd, invalidCmd) < 3)
+    if (suggestion) {
+      console.log('\n  ' + chalk.red(`Did you mean ${chalk.yellow(suggestion)}?`))
     }
   })
 


### PR DESCRIPTION
Say, the user makes a typo.
```bash
$ sb scffold
```

It is always better to suggest the closest match along with the default help message.

<img width="1071" alt="Screenshot 2020-10-01 at 9 05 21 AM" src="https://user-images.githubusercontent.com/25279263/94762595-c85e5c80-03c5-11eb-89cc-c5ecb6230ee3.png">
