### PR TITLE
change delimiter option from boolean to value

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -354,9 +354,10 @@ program
   .requiredOption('-f, --file <FILE_NAME>', 'Name of the file')
   .requiredOption('-t, --type <TYPE>', 'Type of the content')
   .option('-fr, --folder <FOLDER_ID>', '(Optional) This is a Id of folder in storyblok')
-  .option('-d, --delimiter', 'If you are using a csv file, put the file delimiter, the default is ";"')
+  .option('-d, --delimiter <DELIMITER>', 'If you are using a csv file, put the file delimiter, the default is ";"')
   .action(async (options) => {
     const space = program.space
+
     try {
       if (!api.isAuthorized()) {
         await api.processLogin()


### PR DESCRIPTION
Currently when setting a delimiter with the --delimiter paramater it's passed on as either true or false, with this change the actual value will be passed to the CSV parser. 