### PR TITLE
Update the default preset

### DIFF
--- a/src/utils/presets-lib.js
+++ b/src/utils/presets-lib.js
@@ -90,7 +90,7 @@ class PresetsLib {
       const defaultPresetInTarget = componentPresets.find(preset => preset.name === sourcePreset.name)
       return defaultPresetInTarget
     } catch (err) {
-      console.error(`An error occurred while trying to get the "${sourcePreset.name}" preset from target: ${err.message}`)
+      console.error(`An error occurred while trying to get the "${sourcePreset.name}" preset from target space: ${err.message}`)
       return null
     }
   }

--- a/src/utils/presets-lib.js
+++ b/src/utils/presets-lib.js
@@ -83,6 +83,18 @@ class PresetsLib {
     }
   }
 
+  async getSamePresetFromTarget (spaceId, component, sourcePreset) {
+    try {
+      const presetsInTarget = await this.getPresets(spaceId)
+      const componentPresets = this.getComponentPresets(component, presetsInTarget)
+      const defaultPresetInTarget = componentPresets.find(preset => preset.name === sourcePreset.name)
+      return defaultPresetInTarget
+    } catch (err) {
+      console.error(`An error occurred while trying to get the "${sourcePreset.name}" preset from target: ${err.message}`)
+      return null
+    }
+  }
+
   async uploadImageForPreset (image = '') {
     const imageName = last(image.split('/'))
 


### PR DESCRIPTION
This PR fixes an issue with the default preset of components. When components are pushed the default preset is not set for the component. 

### How to test this PR
1. Create a component with at least 1 preset;
2. Set the preset as the default preset for that component;
3. Pull components;
4. Push to target space using the command `storyblok-local push-components SOURC_FILE --space TARGET_SPACE_ID`;
5. Check if the default preset is set for the component in the target space.