### PR TITLE
fix: Translated Slugs sync

### DIFF
--- a/src/tasks/sync.js
+++ b/src/tasks/sync.js
@@ -66,6 +66,25 @@ const SyncSpaces = {
           story: sourceStory,
           force_update: '1'
         }
+        if (sourceStory.translated_slugs) {
+          const sourceTranslatedSlugs = sourceStory.translated_slugs.map(s => {
+            delete s.id
+            return s
+          })
+          if (existingStory.data.stories.length === 1) {
+            const storyData = await this.client.get('spaces/' + this.targetSpaceId + '/stories/' + existingStory.data.stories[0].id)
+            if (storyData.data.story && storyData.data.story.translated_slugs) {
+              const targetTranslatedSlugs = storyData.data.story.translated_slugs
+              sourceTranslatedSlugs.forEach(translation => {
+                if (targetTranslatedSlugs.find(t => t.lang === translation.lang)) {
+                  translation.id = targetTranslatedSlugs.find(t => t.lang === translation.lang).id
+                }
+              })
+            }
+          }
+          payload.story.translated_slugs_attributes = sourceTranslatedSlugs
+          delete payload.story.translated_slugs
+        }
         if (sourceStory.published) {
           payload.publish = '1'
         }


### PR DESCRIPTION
This PR fixes the sync of the translated slugs which is not currently working.

### How to test
1. Install the Translated Slugs app in both source and target space
2. Add a secondary language to both spaces
3. Create an entry and set a custom slug for the secondary language in the source space
4. Run the sync 
5. Check the entry in the target space, you should see also the custom translated slug for the secondary lang