### PR TITLE
Feature/migrations in rt components

### DIFF
--- a/src/tasks/migrations/utils.js
+++ b/src/tasks/migrations/utils.js
@@ -219,6 +219,16 @@ const processMigration = async (content = {}, component = '', migrationFn) => {
         console.error(e)
       }
     }
+
+    if (isPlainObject(value) && value.type === 'doc') {
+      value.content.filter(item => item.type === 'blok').forEach(async (item) => {
+        try {
+          await processMigration(item.attrs.body, component, migrationFn)
+        } catch (e) {
+          console.error(e)
+        }
+      })
+    }
   }
 
   return Promise.resolve(true)

--- a/src/tasks/migrations/utils.js
+++ b/src/tasks/migrations/utils.js
@@ -220,7 +220,7 @@ const processMigration = async (content = {}, component = '', migrationFn) => {
       }
     }
 
-    if (isPlainObject(value) && value.type === 'doc') {
+    if (isPlainObject(value) && value.type === 'doc' && value.content) {
       value.content.filter(item => item.type === 'blok').forEach(async (item) => {
         try {
           await processMigration(item.attrs.body, component, migrationFn)


### PR DESCRIPTION
This PR adds support for migrations to components inside the Rich Text Editor fields. So far migrations would run in components everywhere except for the ones inside the Rich Text Editor.

### How to test this PR
Create a migration for a field of a component that is also inside a Rich Text Editor. Run the migration and you should see the field inside the component inside the Rich Text Editor updated.
The simplest setup would be to use a content type with a single field of type Rich Text in it and then use a component with a single field of type text as the one to use for the migration.