### PR TITLE
fix: execute folders sync first

### DIFF
--- a/src/tasks/sync.js
+++ b/src/tasks/sync.js
@@ -272,7 +272,12 @@ const SyncSpaces = {
 const sync = (types, options) => {
   SyncSpaces.init(options)
 
-  const tasks = types.map(_type => {
+  const tasks = types.sort((a, b) => {
+    if (a === 'folders') return -1
+    if (b === 'folders') return 1
+    return 0
+  }).map(_type => {
+    console.log(_type)
     const command = `sync${capitalize(_type)}`
 
     return () => SyncSpaces[command]()


### PR DESCRIPTION
This PR fixes an issue with the `sync` command. When executing the `sync` command, if both `stories` and `folders` are included in the types but `stories` is before `folders`, there will be an issue with the creation of the entries because they won't have a parent yet.
I added a simple `sort` to the types array right before the sync tasks are executed so the folders sync is always executed first.