### PR TITLE
feat: added option to customize file name on pull-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ $ storyblok select
 Download your space's components schema as json. This command will download 2 files: 1 for the components and 1 for the presets.
 
 ```sh
-$ storyblok pull-components --space <SPACE_ID>
+$ storyblok pull-components --space <SPACE_ID> --file-name <FILE_NAME>
 ```
 
 #### Options
 
 * `space`: your space id
+* `file-name`(optional): a custom filename used to generate the component and present files, default is the space id
 
 ### push-components
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -72,8 +72,9 @@ program
 // pull-components
 program
   .command('pull-components')
+  .option('-f, --file-name <fileName>', 'file-name to use instead of space id')
   .description("Download your space's components schema as json")
-  .action(async () => {
+  .action(async (options) => {
     console.log(`${chalk.blue('-')} Executing pull-components task`)
     const space = program.space
     if (!space) {
@@ -81,13 +82,15 @@ program
       process.exit(0)
     }
 
+    const fileName = options.fileName ? options.fileName : space
+
     try {
       if (!api.isAuthorized()) {
         await api.processLogin()
       }
 
       api.setSpaceId(space)
-      await tasks.pullComponents(api, { space })
+      await tasks.pullComponents(api, { fileName })
     } catch (e) {
       console.log(chalk.red('X') + ' An error occurred when executing the pull-components task: ' + e.message)
       process.exit(1)

--- a/src/tasks/pull-components.js
+++ b/src/tasks/pull-components.js
@@ -20,11 +20,11 @@ const getNameFromComponentGroups = (groups, uuid) => {
 /**
  * @method pullComponents
  * @param  {Object} api
- * @param  {Object} options { space: Number }
+ * @param  {Object} options { fileName: string }
  * @return {Promise<Object>}
  */
 const pullComponents = async (api, options) => {
-  const { space } = options
+  const { fileName } = options
 
   try {
     const componentGroups = await api.getComponentGroups()
@@ -41,7 +41,7 @@ const pullComponents = async (api, options) => {
       }
     })
 
-    const file = `components.${space}.json`
+    const file = `components.${fileName}.json`
     const data = JSON.stringify({ components }, null, 2)
 
     console.log(`${chalk.green('✓')} We've saved your components in the file: ${file}`)
@@ -55,7 +55,7 @@ const pullComponents = async (api, options) => {
       Promise.resolve(file)
     })
 
-    const presetsFile = `presets.${space}.json`
+    const presetsFile = `presets.${fileName}.json`
     const presetsData = JSON.stringify({ presets }, null, 2)
 
     console.log(`${chalk.green('✓')} We've saved your presets in the file: ${presetsFile}`)

--- a/tests/units/pull-components.spec.js
+++ b/tests/units/pull-components.spec.js
@@ -64,7 +64,7 @@ describe('testing pullComponents', () => {
     }
 
     const options = {
-      space: SPACE
+      fileName: SPACE
     }
 
     const expectFileName = `components.${SPACE}.json`


### PR DESCRIPTION
This PR adds the ability to customize the filenames for the `pull-components` command.

After merging users will be able to specify the name like this:

`storyblok pull-components --space <SPACE_ID> --file-name <FILE_NAME>`

This feature is useful for keeping component definition in a repository while working with different spaces.