### PR TITLE
feature: add pull-languages command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -69,6 +69,31 @@ program
     }
   })
 
+// pull-languages
+program
+  .command('pull-languages')
+  .description("Download your space's languages schema as json")
+  .action(async () => {
+    console.log(`${chalk.blue('-')} Executing pull-languages task`)
+    const space = program.space
+    if (!space) {
+      console.log(chalk.red('X') + ' Please provide the space as argument --space YOUR_SPACE_ID.')
+      process.exit(0)
+    }
+
+    try {
+      if (!api.isAuthorized()) {
+        await api.processLogin()
+      }
+
+      api.setSpaceId(space)
+      await tasks.pullLanguages(api, { space })
+    } catch (e) {
+      console.log(chalk.red('X') + ' An error occurred when executing the pull-languages task: ' + e.message)
+      process.exit(1)
+    }
+  })
+
 // pull-components
 program
   .command('pull-components')

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -3,6 +3,7 @@ module.exports = {
   scaffold: require('./scaffold'),
   quickstart: require('./quickstart'),
   pullComponents: require('./pull-components'),
+  pullLanguages: require('./pull-languages'),
   pushComponents: require('./push-components'),
   generateMigration: require('./migrations/generate'),
   runMigration: require('./migrations/run'),

--- a/src/tasks/pull-languages.js
+++ b/src/tasks/pull-languages.js
@@ -1,0 +1,39 @@
+const fs = require('fs')
+const chalk = require('chalk')
+
+/**
+ * @method pullLanguages
+ * @param  {Object} api
+ * @param  {Object} options { space: Number }
+ * @return {Promise<Object>}
+ */
+const pullLanguages = async (api, options) => {
+  const { space } = options
+
+  try {
+    const options = await api.getSpaceOptions()
+    const languages = {
+      default_lang_name: options.default_lang_name,
+      languages: options.languages
+    }
+
+    const file = `languages.${space}.json`
+    const data = JSON.stringify(languages, null, 2)
+
+    console.log(`${chalk.green('✓')} We've saved your languages in the file: ${file}`)
+
+    fs.writeFile(`./${file}`, data, (err) => {
+      if (err) {
+        Promise.reject(err)
+        return
+      }
+
+      Promise.resolve(file)
+    })
+  } catch (e) {
+    console.error(`${chalk.red('X')} An error ocurred in pull-languages task when load components data`)
+    return Promise.reject(new Error(e))
+  }
+}
+
+module.exports = pullLanguages

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -147,6 +147,15 @@ module.exports = {
       .catch(err => Promise.reject(err))
   },
 
+  getSpaceOptions () {
+    const client = this.getClient()
+
+    return client
+      .get(this.getPath(''))
+      .then((data) => data.data.space.options || {})
+      .catch((err) => Promise.reject(err))
+  },
+
   getComponents () {
     const client = this.getClient()
 

--- a/tests/constants.js
+++ b/tests/constants.js
@@ -229,11 +229,31 @@ const FAKE_SPACES = () => [
   }
 ]
 
+const FAKE_SPACE_OPTIONS = () => ({
+  languages: [
+    {
+      code: 'pt',
+      name: 'Português'
+    },
+    {
+      code: 'nl-be',
+      name: 'Dutch (Belgian)'
+    }
+  ],
+  hosted_backup: false,
+  onboarding_step: '3',
+  default_lang_name: 'English',
+  rev_share_enabled: true,
+  required_assest_fields: [],
+  use_translated_stories: false
+})
+
 module.exports = {
   EMAIL_TEST,
   TOKEN_TEST,
   FAKE_STORIES,
   PASSWORD_TEST,
   FAKE_COMPONENTS,
-  FAKE_SPACES
+  FAKE_SPACES,
+  FAKE_SPACE_OPTIONS
 }

--- a/tests/units/pull-languages.spec.js
+++ b/tests/units/pull-languages.spec.js
@@ -1,0 +1,62 @@
+const fs = require('fs')
+const pullLanguages = require('../../src/tasks/pull-languages')
+const { FAKE_SPACE_OPTIONS } = require('../constants')
+
+jest.mock('fs')
+
+describe('testing pullLanguages', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('api.getSpaceOptions() should be called once time', () => {
+    const api = {
+      getSpaceOptions: jest.fn(() => Promise.resolve(FAKE_SPACE_OPTIONS()))
+    }
+
+    return pullLanguages(api, {})
+      .then(() => {
+        expect(api.getSpaceOptions.mock.calls.length).toBe(1)
+      })
+  })
+
+  it('api.getSpaceOptions() should be call fs.writeFile correctly', async () => {
+    const SPACE = 12345
+    const BODY = FAKE_SPACE_OPTIONS()
+
+    const api = {
+      getSpaceOptions () {
+        return Promise.resolve(BODY)
+      }
+    }
+
+    const options = {
+      space: SPACE
+    }
+
+    const expectFileName = `languages.${SPACE}.json`
+    const expectData = {
+      default_lang_name: BODY.default_lang_name,
+      languages: BODY.languages
+    }
+
+    return pullLanguages(api, options)
+      .then(_ => {
+        const [path, data] = fs.writeFile.mock.calls[0]
+
+        expect(fs.writeFile.mock.calls.length).toBe(1)
+        expect(path).toBe(`./${expectFileName}`)
+        expect(JSON.parse(data)).toEqual(expectData)
+      })
+  })
+
+  it('api.getSpaceOptions() when a error ocurred, catch the body response', async () => {
+    const _api = {
+      getSpaceOptions (_, fn) {
+        return Promise.reject(new Error('Failed'))
+      }
+    }
+
+    await expect(pullLanguages(_api, {})).rejects.toThrow('Error: Failed')
+  })
+})


### PR DESCRIPTION
Adds feature to pull languages to a file
Similar to pull components but for languages

```bash
$ storyblok pull-languages --space 123456
```

Will store in a file named: `languages.123456.json`

With the following structure:
```json
{
  "default_lang_name": "English",
  "languages": [
    {
      "code": "pt",
      "name": "Português"
    },
    {
      "code": "nl-be",
      "name": "Dutch (Belgian)"
    }
  ]
}
```