### PR TITLE
refactor(int-532): adding a new parameter to show errors on migration command

### DIFF
--- a/src/tasks/sync-commands/datasources.js
+++ b/src/tasks/sync-commands/datasources.js
@@ -136,7 +136,7 @@ class SyncDatasources {
         console.log(chalk.green('✓') + ' Created datasource ' + datasourcesToAdd[i].name)
       } catch (err) {
         console.error(
-          `${chalk.red('X')} Datasource ${datasourcesToAdd[i].name} creation failed: ${err.message}`
+          `${chalk.red('X')} Datasource ${datasourcesToAdd[i].name} creation failed: ${err.response.data.error || err.message}`
         )
       }
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-532](https://storyblok.atlassian.net/browse/INT-532)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Refactoring (no functional changes, no api changes)

## How to test this PR

Run the CLI locally and run the datasources migration command, if the target space is not in one of the Community, Teams, Entry or Enterprice plans you will see the message saying which plan it should be in instead of just showing a 429 error.

```sh
node ./src/cli.js sync --type datasources --source 123456 --target 654321
```

**Before this PR**

![image-20220823-171744](https://user-images.githubusercontent.com/40925579/186730188-ba76e127-4146-4eb2-804c-cfb00ea44e4f.png)

**After this PR**

<img width="1176" alt="Screen Shot 2022-08-23 at 16 31 35 (1)" src="https://user-images.githubusercontent.com/40925579/186730231-abe86dde-db6c-4bef-95a2-a1f550f6b50f.png">

