### PR TITLE
feat: add support for us region

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -34,12 +34,14 @@ program.version(pkg.version)
 
 program
   .option('-s, --space [value]', 'space ID')
+  .option('-r, --region [value]', 'Region')
 
 // login
 program
   .command('login')
   .description('Login to the Storyblok cli')
   .action(async () => {
+    api.setRegion(program.region)
     if (api.isAuthorized()) {
       console.log(chalk.green('✓') + ' The user has been already logged. If you want to change the logged user, you must logout and login again')
       return
@@ -59,6 +61,7 @@ program
   .command('logout')
   .description('Logout from the Storyblok cli')
   .action(async () => {
+    api.setRegion(program.region)
     try {
       await api.logout()
       console.log('Logged out successfully! Token has been removed from .netrc file.')
@@ -74,6 +77,7 @@ program
   .command('pull-components')
   .description("Download your space's components schema as json")
   .action(async () => {
+    api.setRegion(program.region)
     console.log(`${chalk.blue('-')} Executing pull-components task`)
     const space = program.space
     if (!space) {
@@ -87,7 +91,7 @@ program
       }
 
       api.setSpaceId(space)
-      await tasks.pullComponents(api, { space })
+      await tasks.pullComponents(api, { space, region: program.region })
     } catch (e) {
       console.log(chalk.red('X') + ' An error occurred when executing the pull-components task: ' + e.message)
       process.exit(1)
@@ -100,6 +104,7 @@ program
   .option('-p, --presets-source <presetsSource>', 'Path to presets file')
   .description("Download your space's components schema as json. The source parameter can be a URL to your JSON file or a path to it")
   .action(async (source, options) => {
+    api.setRegion(program.region)
     console.log(`${chalk.blue('-')} Executing push-components task`)
     const space = program.space
     const presetsSource = options.presetsSource
@@ -114,7 +119,7 @@ program
         await api.processLogin()
       }
       api.setSpaceId(space)
-      await tasks.pushComponents(api, { source, presetsSource })
+      await tasks.pushComponents(api, { source, presetsSource, region: program.region })
     } catch (e) {
       console.log(chalk.red('X') + ' An error occurred when executing the push-components task: ' + e.message)
       process.exit(1)
@@ -126,6 +131,7 @@ program
   .command('scaffold <name>')
   .description('Scaffold <name> component')
   .action(async (name) => {
+    api.setRegion(program.region)
     console.log(`${chalk.blue('-')} Scaffolding a component\n`)
 
     if (api.isAuthorized()) {
@@ -149,6 +155,7 @@ program
   .command('select')
   .description('Usage to kickstart a boilerplate, fieldtype or theme')
   .action(async () => {
+    api.setRegion(program.region)
     console.log(`${chalk.blue('-')} Select a boilerplate, fieldtype or theme to initialize\n`)
 
     try {
@@ -157,7 +164,7 @@ program
 
       await lastStep(answers)
     } catch (e) {
-      console.error(chalk.red('X') + ' An error ocurred when execute the select command: ' + e.message)
+      console.error(chalk.red('X') + ' An error occurred when execute the select command: ' + e.message)
       process.exit(1)
     }
   })
@@ -170,6 +177,7 @@ program
   .requiredOption('--source <SPACE_ID>', 'Source space id')
   .requiredOption('--target <SPACE_ID>', 'Target space id')
   .action(async (options) => {
+    api.setRegion(program.region)
     console.log(`${chalk.blue('-')} Sync data between spaces\n`)
 
     const {
@@ -196,12 +204,13 @@ program
       await tasks.sync(_types, {
         token,
         source,
-        target
+        target,
+        region: program.region
       })
 
       console.log('\n' + chalk.green('✓') + ' Sync data between spaces successfully completed')
     } catch (e) {
-      console.error(chalk.red('X') + ' An error ocurred when syncing spaces: ' + e.message)
+      console.error(chalk.red('X') + ' An error occurred when syncing spaces: ' + e.message)
       process.exit(1)
     }
   })
@@ -211,13 +220,14 @@ program
   .command('quickstart')
   .description('Start a project quickly')
   .action(async () => {
+    api.setRegion(program.region)
     try {
       const space = program.space
       const questions = getQuestions('quickstart', { space }, api)
       const answers = await inquirer.prompt(questions)
       await tasks.quickstart(api, answers, space)
     } catch (e) {
-      console.log(chalk.red('X') + ' An error ocurred when execute quickstart operations: ' + e.message)
+      console.log(chalk.red('X') + ' An error occurred when execute quickstart operations: ' + e.message)
       process.exit(1)
     }
   })
@@ -228,6 +238,7 @@ program
   .requiredOption('-c, --component <COMPONENT_NAME>', 'Name of the component')
   .requiredOption('-f, --field <FIELD_NAME>', 'Name of the component field')
   .action(async (options) => {
+    api.setRegion(program.region)
     const field = options.field || ''
     const component = options.component || ''
 
@@ -247,7 +258,7 @@ program
       api.setSpaceId(space)
       await tasks.generateMigration(api, component, field)
     } catch (e) {
-      console.log(chalk.red('X') + ' An error ocurred when generate the migration file: ' + e.message)
+      console.log(chalk.red('X') + ' An error occurred when generate the migration file: ' + e.message)
       process.exit(1)
     }
   })
@@ -261,6 +272,7 @@ program
   .option('--publish <PUBLISH_OPTION>', 'Publish the content. It can be: all, published or published-with-changes')
   .option('--publish-languages <LANGUAGES>', 'Publish specific languages')
   .action(async (options) => {
+    api.setRegion(program.region)
     const field = options.field || ''
     const component = options.component || ''
     const isDryrun = !!options.dryrun
@@ -298,7 +310,7 @@ program
         { isDryrun, publish, publishLanguages }
       )
     } catch (e) {
-      console.log(chalk.red('X') + ' An error ocurred when run the migration file: ' + e.message)
+      console.log(chalk.red('X') + ' An error occurred when run the migration file: ' + e.message)
       process.exit(1)
     }
   })
@@ -309,6 +321,7 @@ program
   .requiredOption('-c, --component <COMPONENT_NAME>', 'Name of the component')
   .requiredOption('-f, --field <FIELD_NAME>', 'Name of the component field')
   .action(async (options) => {
+    api.setRegion(program.region)
     const field = options.field || ''
     const component = options.component || ''
     const space = program.space
@@ -326,7 +339,7 @@ program
 
       await tasks.rollbackMigration(api, field, component)
     } catch (e) {
-      console.log(chalk.red('X') + ' An error ocurred when run rollback-migration: ' + e.message)
+      console.log(chalk.red('X') + ' An error occurred when run rollback-migration: ' + e.message)
       process.exit(1)
     }
   })
@@ -336,6 +349,7 @@ program
   .command('spaces')
   .description('List all spaces of the logged account')
   .action(async () => {
+    api.setRegion(program.region)
     try {
       if (!api.isAuthorized()) {
         await api.processLogin()
@@ -343,7 +357,7 @@ program
 
       await tasks.listSpaces(api)
     } catch (e) {
-      console.log(chalk.red('X') + ' An error ocurred to listing sapces : ' + e.message)
+      console.log(chalk.red('X') + ' An error occurred to listing spaces : ' + e.message)
       process.exit(1)
     }
   })
@@ -357,6 +371,7 @@ program
   .option('-fr, --folder <FOLDER_ID>', '(Optional) This is a Id of folder in storyblok')
   .option('-d, --delimiter <DELIMITER>', 'If you are using a csv file, put the file delimiter, the default is ";"')
   .action(async (options) => {
+    api.setRegion(program.region)
     const space = program.space
 
     try {
@@ -376,7 +391,7 @@ program
         `${chalk.green('✓')} The import process was executed with success!`
       )
     } catch (e) {
-      console.log(chalk.red('X') + ' An error ocurred to import data : ' + e.message)
+      console.log(chalk.red('X') + ' An error occurred to import data : ' + e.message)
       process.exit(1)
     }
   })

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,10 @@
-const API_URL = 'https://api.storyblok.com/v1/'
-const LOGIN_URL = `${API_URL}users/login`
-const SIGNUP_URL = `${API_URL}users/signup`
+const EU_API_URL = 'https://api.storyblok.com/v1/'
+const EU_LOGIN_URL = `${EU_API_URL}users/login`
+const EU_SIGNUP_URL = `${EU_API_URL}users/signup`
+
+const US_API_URL = 'https://api-us.storyblok.com/v1/'
+const US_LOGIN_URL = `${US_API_URL}users/login`
+const US_SIGNUP_URL = `${US_API_URL}users/signup`
 
 const SYNC_TYPES = [
   'folders',
@@ -11,8 +15,11 @@ const SYNC_TYPES = [
 ]
 
 module.exports = {
-  LOGIN_URL,
-  SIGNUP_URL,
-  API_URL,
+  EU_LOGIN_URL,
+  EU_SIGNUP_URL,
+  EU_API_URL,
+  US_API_URL,
+  US_LOGIN_URL,
+  US_SIGNUP_URL,
   SYNC_TYPES
 }

--- a/src/tasks/push-components.js
+++ b/src/tasks/push-components.js
@@ -53,7 +53,7 @@ module.exports = async (api, { source, presetsSource }) => {
 }
 
 const push = async (api, components, presets = []) => {
-  const presetsLib = new PresetsLib({ oauthToken: api.accessToken, targetSpaceId: api.spaceId })
+  const presetsLib = new PresetsLib({ oauthToken: api.accessToken, targetSpaceId: api.spaceId, region: api.region })
   try {
     const componentsGroups = await api.getComponentGroups()
     for (let i = 0; i < components.length; i++) {
@@ -103,7 +103,7 @@ const push = async (api, components, presets = []) => {
       if (schema) {
         Object.keys(schema).forEach(field => {
           if (schema[field].component_group_whitelist) {
-            schema[field].component_group_whitelist = schema[field].component_group_whitelist.map(uuid => 
+            schema[field].component_group_whitelist = schema[field].component_group_whitelist.map(uuid =>
               getGroupByUuid(componentsGroups, uuid) ? getGroupByUuid(componentsGroups, uuid).uuid : uuid
             )
           }

--- a/src/tasks/sync-commands/component-groups.js
+++ b/src/tasks/sync-commands/component-groups.js
@@ -4,7 +4,7 @@ const { findByProperty } = require('../../utils')
 
 class SyncComponentGroups {
   /**
-   * @param {{ sourceSpaceId: string, targetSpaceId: string, oauthToken: string }} options
+   * @param {{ sourceSpaceId: string, targetSpaceId: string, oauthToken: string, region: string}} options
    */
   constructor (options) {
     this.sourceSpaceId = options.sourceSpaceId
@@ -15,7 +15,8 @@ class SyncComponentGroups {
     this.targetComponentGroups = []
 
     this.client = new StoryblokClient({
-      oauthToken: options.oauthToken
+      oauthToken: options.oauthToken,
+      region: options.region
     })
   }
 

--- a/src/tasks/sync-commands/components.js
+++ b/src/tasks/sync-commands/components.js
@@ -7,7 +7,7 @@ const PresetsLib = require('../../utils/presets-lib')
 
 class SyncComponents {
   /**
-   * @param {{ sourceSpaceId: string, targetSpaceId: string, oauthToken: string }} options
+   * @param {{ sourceSpaceId: string, targetSpaceId: string, oauthToken: string, region: string }} options
    */
   constructor (options) {
     this.sourcePresets = []
@@ -15,18 +15,25 @@ class SyncComponents {
     this.sourceComponents = []
     this.sourceSpaceId = options.sourceSpaceId
     this.targetSpaceId = options.targetSpaceId
+    this.region = options.region
     this.oauthToken = options.oauthToken
     this.client = new StoryblokClient({
-      oauthToken: options.oauthToken
+      oauthToken: options.oauthToken,
+      region: options.region
     })
-    this.presetsLib = new PresetsLib({ oauthToken: options.oauthToken, targetSpaceId: this.targetSpaceId })
+    this.presetsLib = new PresetsLib({
+      oauthToken: options.oauthToken,
+      targetSpaceId: this.targetSpaceId,
+      region: this.region
+    })
   }
 
   async sync () {
     const syncComponentGroupsInstance = new SyncComponentGroups({
       oauthToken: this.oauthToken,
       sourceSpaceId: this.sourceSpaceId,
-      targetSpaceId: this.targetSpaceId
+      targetSpaceId: this.targetSpaceId,
+      region: this.region
     })
 
     try {

--- a/src/tasks/sync-commands/datasources.js
+++ b/src/tasks/sync-commands/datasources.js
@@ -3,7 +3,7 @@ const StoryblokClient = require('storyblok-js-client')
 
 class SyncDatasources {
   /**
-   * @param {{ sourceSpaceId: string, targetSpaceId: string, oauthToken: string }} options
+   * @param {{ sourceSpaceId: string, targetSpaceId: string, oauthToken: string, region: string }} options
    */
   constructor (options) {
     this.targetDatasources = []
@@ -12,7 +12,8 @@ class SyncDatasources {
     this.targetSpaceId = options.targetSpaceId
     this.oauthToken = options.oauthToken
     this.client = new StoryblokClient({
-      oauthToken: options.oauthToken
+      oauthToken: options.oauthToken,
+      region: options.region
     })
   }
 

--- a/src/tasks/sync.js
+++ b/src/tasks/sync.js
@@ -14,8 +14,10 @@ const SyncSpaces = {
     this.sourceSpaceId = options.source
     this.targetSpaceId = options.target
     this.oauthToken = options.token
+    this.region = options.region
     this.client = new StoryblokClient({
-      oauthToken: options.token
+      oauthToken: options.token,
+      region: options.region
     }, options.api)
   },
 
@@ -228,7 +230,8 @@ const SyncSpaces = {
     const syncComponentsInstance = new SyncComponents({
       sourceSpaceId: this.sourceSpaceId,
       targetSpaceId: this.targetSpaceId,
-      oauthToken: this.oauthToken
+      oauthToken: this.oauthToken,
+      region: this.region
     })
 
     try {
@@ -247,7 +250,8 @@ const SyncSpaces = {
     const syncDatasourcesInstance = new SyncDatasources({
       sourceSpaceId: this.sourceSpaceId,
       targetSpaceId: this.targetSpaceId,
-      oauthToken: this.oauthToken
+      oauthToken: this.oauthToken,
+      region: this.region
     })
 
     try {
@@ -266,7 +270,7 @@ const SyncSpaces = {
 /**
  * @method sync
  * @param  {Array} types
- * @param  {*} options      { token: String, source: Number, target: Number, api: String }
+ * @param  {*} options      { token: String, source: Number, target: Number, api: String, region: string }
  * @return {Promise}
  */
 const sync = (types, options) => {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -5,16 +5,30 @@ const inquirer = require('inquirer')
 
 const creds = require('./creds')
 const getQuestions = require('./get-questions')
-const { LOGIN_URL, SIGNUP_URL, API_URL } = require('../constants')
+const {
+  EU_API_URL, EU_LOGIN_URL, EU_SIGNUP_URL, US_API_URL, US_LOGIN_URL, US_SIGNUP_URL
+} = require('../constants')
 
 module.exports = {
   accessToken: '',
   spaceId: null,
+  region: 'EU',
+
+  setRegion (region) {
+    this.region = region && region.toLowerCase()
+    if (this.region) {
+      console.log(chalk.green('✓') + ' Setting region to: ', this.region.toUpperCase() || 'EU')
+    }
+
+    this.API_URL = this.region === 'us' ? US_API_URL : EU_API_URL
+    this.LOGIN_URL = this.region === 'us' ? US_LOGIN_URL : EU_LOGIN_URL
+    this.SIGNUP_URL = this.region === 'us' ? US_SIGNUP_URL : EU_SIGNUP_URL
+  },
 
   getClient () {
     return new Storyblok({
       oauthToken: this.accessToken
-    }, API_URL)
+    }, this.API_URL)
   },
 
   getPath (path) {
@@ -27,7 +41,7 @@ module.exports = {
 
   async login (email, password) {
     try {
-      const response = await axios.post(LOGIN_URL, {
+      const response = await axios.post(this.LOGIN_URL, {
         email: email,
         password: password
       })
@@ -52,7 +66,7 @@ module.exports = {
 
         const { otp_attempt: code } = await inquirer.prompt(questions)
 
-        const newResponse = await axios.post(LOGIN_URL, {
+        const newResponse = await axios.post(this.LOGIN_URL, {
           email: email,
           password: password,
           otp_attempt: code
@@ -109,7 +123,7 @@ module.exports = {
   },
 
   signup (email, password) {
-    return axios.post(SIGNUP_URL, {
+    return axios.post(this.SIGNUP_URL, {
       email: email,
       password: password
     })

--- a/src/utils/creds.js
+++ b/src/utils/creds.js
@@ -3,7 +3,7 @@ var fs = require('fs')
 var netrc = require('netrc')
 var os = require('os')
 
-var host = 'api.storyblok.com'
+var host = 'api-us.storyblok.com'
 
 const getFile = () => {
   const home = process.env[(/^win/.test(process.platform)) ? 'USERPROFILE' : 'HOME']

--- a/src/utils/presets-lib.js
+++ b/src/utils/presets-lib.js
@@ -6,12 +6,13 @@ const { last } = require('lodash')
 
 class PresetsLib {
   /**
-   * @param {{ oauthToken: string, targetSpaceId: int }} options
+   * @param {{ oauthToken: string, targetSpaceId: int, region: string }} options
    */
   constructor (options) {
     this.oauthToken = options.oauthToken
     this.client = new StoryblokClient({
-      oauthToken: options.oauthToken
+      oauthToken: options.oauthToken,
+      region: options.region
     })
     this.targetSpaceId = options.targetSpaceId
   }


### PR DESCRIPTION
This PR will add a new flag `-r, --region <region>` which will enable the dynamic switching between `api.storyblok.com` and `api-us.storyblok.com` so that the CLI will have support for US-based spaces.