### PR TITLE
story(int-571): Implement Dimensions Datasource migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "open": "^6.0.0",
     "p-series": "^2.1.0",
     "path": "^0.12.7",
+    "simple-uuid": "^0.0.1",
     "storyblok-js-client": "^3.3.1",
     "update-notifier": "^5.1.0",
     "xml-js": "^1.6.11"

--- a/src/tasks/sync-commands/datasources.js
+++ b/src/tasks/sync-commands/datasources.js
@@ -152,7 +152,7 @@ class SyncDatasources {
         }
       } catch (err) {
         console.error(
-          `${chalk.red('X')} Datasource ${datasourcesToAdd[i].name} creation failed: ${err.message}`
+          `${chalk.red('X')} Datasource ${datasourcesToAdd[i].name} creation failed: ${err.response.data.error || err.message}`
         )
       }
     }

--- a/src/tasks/sync.js
+++ b/src/tasks/sync.js
@@ -45,29 +45,29 @@ const SyncSpaces = {
 
   async syncStories () {
     console.log(chalk.green('✓') + ' Syncing stories...')
-    var targetFolders = await this.client.getAll(`spaces/${this.targetSpaceId}/stories`, {
+    const targetFolders = await this.client.getAll(`spaces/${this.targetSpaceId}/stories`, {
       folder_only: 1,
       sort_by: 'slug:asc'
     })
 
-    var folderMapping = {}
+    const folderMapping = {}
 
     for (let i = 0; i < targetFolders.length; i++) {
       var folder = targetFolders[i]
       folderMapping[folder.full_slug] = folder.id
     }
 
-    var all = await this.client.getAll(`spaces/${this.sourceSpaceId}/stories`, {
+    const all = await this.client.getAll(`spaces/${this.sourceSpaceId}/stories`, {
       story_only: 1
     })
 
     for (let i = 0; i < all.length; i++) {
       console.log(chalk.green('✓') + ' Starting update ' + all[i].full_slug)
 
-      var storyResult = await this.client.get('spaces/' + this.sourceSpaceId + '/stories/' + all[i].id)
-      var sourceStory = storyResult.data.story
-      var slugs = sourceStory.full_slug.split('/')
-      var folderId = 0
+      const { data } = await this.client.get('spaces/' + this.sourceSpaceId + '/stories/' + all[i].id)
+      const sourceStory = data.story
+      const slugs = sourceStory.full_slug.split('/')
+      let folderId = 0
 
       if (slugs.length > 1) {
         slugs.pop()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4210,6 +4210,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
   integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
 
+simple-uuid@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/simple-uuid/-/simple-uuid-0.0.1.tgz#bd3edd78f9e55f07093adb9fba6fed87fb8e2a75"
+  integrity sha512-ntM3nHmSaNrSfRL1M9xhnjS5dj9897VsNu4tIzrIk5+ESXPS9SIbwu20zcK+SrMllpcXW4qR4KhX0LXggox1AQ==
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"


### PR DESCRIPTION
⚠️ ⚠️   **This command doesn't work with US servers yet, this feature is still under development.** ⚠️ ⚠️ 

## Pull request type

Jira Link: [INT-571](https://storyblok.atlassian.net/browse/INT-571)

Please check the type of change your PR introduces:-->

- [x] Feature

## How to test this PR

With this PR it will be possible to sync datasources with dimensions between spaces, in the sync all the content of dimensions will be migrated automatically.

To test the PR you need to get this branch `story/int-571` and run the following command in your machine 

```sh
node ./src/cli.js sync --type datasources --source 123456 --target 654321
```

It would be nice to test with large datasources, with many entries and several dimensions, to validate the code functioning

## What is the new behavior?

- Now it's possible to sync datasources and dimensions to other spaces

