### PR TITLE
fix: publish status not being synced correctly

### DIFF
--- a/src/tasks/sync.js
+++ b/src/tasks/sync.js
@@ -89,7 +89,7 @@ const SyncSpaces = {
         const payload = {
           story: storyData,
           force_update: '1',
-          ...(sourceStory.published ? { published: 1 } : {})
+          ...(sourceStory.published ? { publish: 1 } : {})
         }
 
         let createdStory = null


### PR DESCRIPTION
Hello,

when syncing stories, the published state is not being synced correctly due to a typo in the sync task:
https://github.com/storyblok/storyblok/blob/45838cbe750c5354ee8dcd9c3ce584d38baa1152/src/tasks/sync.js#L92

As per [docs](https://www.storyblok.com/docs/api/management#core-resources/stories/update-story) it should be `publish` instead of `published` 

This PR fixes the typo.
```typescript
...(sourceStory.published ? { publish: 1 } : {})
```
