### PR TITLE
bugfix(int-423): Syncing of component groups in RichText

### DIFF
--- a/src/tasks/sync-commands/components.js
+++ b/src/tasks/sync-commands/components.js
@@ -210,7 +210,7 @@ class SyncComponents {
     return Object.keys(sourceSchema).reduce((acc, key) => {
       // handle blocks separately
       const sourceSchemaItem = sourceSchema[key]
-      if (sourceSchemaItem.type === 'bloks' || sourceSchemaItem.type === 'richtext') {
+      if (sourceSchemaItem?.type === 'bloks' || sourceSchemaItem?.type === 'richtext') {
         acc[key] = this.mergeBloksSchema(sourceSchemaItem)
         return acc
       }


### PR DESCRIPTION
## Pull request type

Jira Link: [INT-423](https://storyblok.atlassian.net/browse/INT-423)

<!-- Please try to limit your pull request to one type, and submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix

## How to test this PR

You can check the problem described in this [issue](https://github.com/storyblok/storyblok/issues/801) and check the videos below.

**Before**:

https://user-images.githubusercontent.com/40925579/199072261-813a5cdd-10ca-48c9-bc07-9632ccb2c7ea.mov

**After**:

https://user-images.githubusercontent.com/40925579/199072448-9add107d-8953-4f8f-a253-d210df70c5f7.mov

## What is the new behavior?

- Block and constraint definitions now work for RichText and no longer just for FieldType Blocks

## Other information
